### PR TITLE
'indexes', as an analogy to 'fins', which returns a Prod of all Indexes of a given length

### DIFF
--- a/src/Data/Type/Product.hs
+++ b/src/Data/Type/Product.hs
@@ -230,6 +230,15 @@ select = \case
   Ø     -> pure Ø
   x:<xs -> (:<) <$> index x <*> select xs
 
+indexes :: forall as. Known Length as => Prod (Index as) as
+indexes = indexes' known
+
+indexes' :: Length as -> Prod (Index as) as
+indexes' = \case
+  LZ   -> Ø
+  LS l -> IZ :< map1 IS (indexes' l)
+
+
 instance Functor1 Prod where
   map1 f = \case
     Ø -> Ø


### PR DESCRIPTION
nothing too major, but I've found this useful in my own projects.  It could be implemented in terms of `elimLength` or just one-offed, but I felt like it might be generally useful enough to put in here.  feel free to close if you feel there's a simpler/more concise way that makes this obsolete, or if you think it's too obscure to warrant putting in/not in the spirit of the library :)