### PR TITLE
More instances for Data.Type.Vector.M

### DIFF
--- a/src/Data/Type/Vector.hs
+++ b/src/Data/Type/Vector.hs
@@ -15,6 +15,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Type.Vector
@@ -258,6 +260,16 @@ instance Num (Matrix ns a) => Num (M ns a) where
   M a - M b    = M $ a - b
   abs (M a)    = M $ abs a
   signum (M a) = M $ signum a
+
+deriving instance Functor  (Matrix ns) => Functor  (M ns)
+deriving instance Foldable (Matrix ns) => Foldable (M ns)
+
+instance Applicative (Matrix ns) => Applicative (M ns) where
+  pure = M . pure
+  M f <*> M a = M $ f <*> a
+
+instance Monad (Matrix ns) => Monad (M ns) where
+  M ma >>= f = M (ma >>= getMatrix . f)
 
 type family Matrix (ns :: [N]) :: * -> * where
   Matrix Ø         = I


### PR DESCRIPTION

> `M` matrix newtype:
>  * Derived Functor and Foldable instances.
>  * Wrote Applicative and Monad instances.

The Functor and Foldable instances in particular are quite useful since they allow both to be derived for a data-type with an `M ns a` field. In my use case Applicative is also useful, so I wrote that too. Monad I just added because it seemed like the thing to do after Functor and Applicative.