### PR TITLE
Vector utils

### DIFF
--- a/src/Data/Type/Fin/Indexed.hs
+++ b/src/Data/Type/Fin/Indexed.hs
@@ -34,7 +34,7 @@ module Data.Type.Fin.Indexed where
 
 import Data.Type.Nat
 import Type.Class.Higher
--- import Type.Class.Known
+import Type.Class.Known
 import Type.Class.Witness
 import Type.Family.Constraint
 import Type.Family.Nat
@@ -93,6 +93,11 @@ ifinNat = \case
   IFZ   -> Z_
   IFS n -> S_ $ ifinNat n
 
+deIndex :: IFin n m -> Fin n
+deIndex = \case
+  IFS n -> FS (deIndex n)
+  IFZ   -> FZ
+
 ifinVal :: IFin x y -> Int
 ifinVal = natVal . ifinNat
 
@@ -122,6 +127,13 @@ instance (x' ~ Pred x) => Witness ØC (S x' ~ x) (IFin x y) where
   (\\) r = \case
     IFZ   -> r
     IFS _ -> r
+
+instance Known (IFin (S n)) Z where
+  known = IFZ
+
+instance Known (IFin n) m => Known (IFin (S n)) (S m) where
+  type KnownC (IFin (S n)) (S m) = Known (IFin n) m
+  known = IFS known
 
 {-
 elimFin :: (forall x. p (S x))

--- a/src/Data/Type/Vector.hs
+++ b/src/Data/Type/Vector.hs
@@ -213,6 +213,11 @@ vSetAt n = vUpdateAt n . const
 data Range n l m = Range (IFin ('S n) l) (IFin ('S n) (l + m))
   deriving (Show, Eq)
 
+instance (Known (IFin (S n)) l, Known (IFin (S n)) (l + m))
+  => Known (Range n l) m where
+  type KnownC (Range n l) m = (Known (IFin (S n)) l, Known (IFin (S n)) (l + m))
+  known = Range known known
+
 updateRange :: Range n l m -> (Fin m -> f a -> f a) -> VecT n f a -> VecT n f a
 updateRange = \case
   Range  IFZ     IFZ    -> \_ -> id


### PR DESCRIPTION
> Extend Data.Type.Vector with assorted vector and matrix utilities.

I was writing vector/matrix utilities for use with termonad, but they ended up being very general so I figured it would be best to upstream them. Let me know if there are any changes I should make to the implementation or the types, or if you want me to cut out certain functions; they can be kept downstream.

> Wrote `Known` instances for the singleton `IFin` and `Range` types;
> added `deIndex :: IFin n m -> Fin n`.

Since the added utilities use `IFin` and `Range` a lot and they're singletons, a `Known` instance seems like the best way to ease their construction. `deIndex` then aids in the construction of `Fin n` values.

Edit: This PR doesn't depend upon #11 as is, but there are a few places it can be simplified if #11 is merged first.